### PR TITLE
uppercase/lowercase nas requisições

### DIFF
--- a/tests/test_views/institutes_view_test.py
+++ b/tests/test_views/institutes_view_test.py
@@ -27,5 +27,10 @@ class InstituteViewTest(TestCase):
         data = response.json
         self.assertIsInstance(data, dict)
 
+    def test_get_lowercase(self):
+        response = self.app.get('/institutos/ic', status=200)
+        data = response.json
+        self.assertIsInstance(data, dict)
+
     def test_get_not_found(self):
         self.app.get('/institutos/ICdjjadij', status=404, expect_errors=True)


### PR DESCRIPTION
Atualiza a issue #38. Fiz o método `_process_request_params` nos resources, que é chamado na inicialização dos recursos. Nesse método, nós podemos separarar, preprocessar e interpretar os parâmetros da requisição.
É uma solução bem mais ou menos... Eu tenho uma outra ideia e gostaria de mostrar nessa PR mesmo (e se vocês não gostarem, então eu volto pro que está agora).